### PR TITLE
Remove modern-isomorphic-ws as it's now included in Node.js 22.4.0+ without needing an experimental flag.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "neuro-game-sdk",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neuro-game-sdk",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "modern-isomorphic-ws": "^1.0.5",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -366,15 +365,6 @@
         "node": "*"
       }
     },
-    "node_modules/modern-isomorphic-ws": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/modern-isomorphic-ws/-/modern-isomorphic-ws-1.0.5.tgz",
-      "integrity": "sha512-cgJzdkn1//XyYJsFZkjPYKN21CXeG+KC38Q5uFwTnbUwG3pmmsUDS9a5RRJ6lFnjsnEbUKx+rIXjxX/uCUFYvQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "^8.11.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -503,28 +493,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "author": "ArieX",
   "license": "MIT",
   "dependencies": {
-    "tslib": "^2.8.1",
-    "modern-isomorphic-ws": "^1.0.5"
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import WebSocket from 'modern-isomorphic-ws'
-
 /**
  * Messages sent by the game (client) to Neuro (server).
  */


### PR DESCRIPTION
Yeah I didn't realise this either until today when I tried to install the package and it set a deprecation message.